### PR TITLE
Merge pull request #16 from dantecalderon/fix-loading-404-in-app-routes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,3 +2,8 @@
   command = "npm run build"
   functions = "functions-src"
   publish = "public"
+
+[[redirects]]
+  from = "/app/*"
+  to = "/app.html"
+  status = 200


### PR DESCRIPTION
As described here #7. The app/* routes load 404 page before.
I use the @CarlBrownDatacom suggestion, adding additional config in `netlify.toml` to redirect routes.